### PR TITLE
Add ssh key spec, public ip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Do [install](https://terragrunt.gruntwork.io/docs/getting-started/install/) it i
 | ebs_volume_size           | Size of EBS volume to be used by mongo container                       | number | `n/a`   | yes      |
 | ebs_volume_type           | Type of EBS volume to be used by mongo container                       | string | `n/a`   | yes      |
 | instance_type             | Type of EC2 instance to be used by ECS cluster for mongo task          | string | `n/a`   | yes      |
+| instance_ssh_key_pair_name| The key pair name to use to access the EC2 instance                    | string | `null`  | no       |
+| instance_enable_public_ip | If true, assigns a public ip to the EC2 instance                       | bool   | `false` | no       |
 | region                    | Region to be used for creating all the above resources                 | string | `n/a`   | yes      |
 | stage                     | Stage of the deployment                                                | string | `n/a`   | yes      |
 | mongo_container_cpu       | CPU capacity to be allocated for mongo container                       | number | `n/a`   | yes      |

--- a/ec2-resources.tf
+++ b/ec2-resources.tf
@@ -4,7 +4,7 @@ data "aws_ami" "amazon-linux-2" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*-ebs"]
+    values = ["amzn2-ami-ecs-hvm-*-x86_64-ebs"]
   }
 }
 

--- a/ec2-resources.tf
+++ b/ec2-resources.tf
@@ -9,13 +9,14 @@ data "aws_ami" "amazon-linux-2" {
 }
 
 resource "aws_instance" "mongo-ecs-instance" {
-  ami                    = data.aws_ami.amazon-linux-2.id
-  instance_type          = var.instance_type
-  vpc_security_group_ids = [var.security_group_id]
-  subnet_id              = var.subnet_id
-  iam_instance_profile   = aws_iam_instance_profile.default.id
-  user_data              = data.template_file.user-data.rendered
-
+  ami                         = data.aws_ami.amazon-linux-2.id
+  instance_type               = var.instance_type
+  vpc_security_group_ids      = [var.security_group_id]
+  subnet_id                   = var.subnet_id
+  iam_instance_profile        = aws_iam_instance_profile.default.id
+  user_data                   = data.template_file.user-data.rendered
+  key_name                    = var.instance_ssh_key_pair_name == "" ? null : var.instance_ssh_key_pair_name
+  associate_public_ip_address = var.instance_enable_public_ip
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,15 @@ variable "subnet_id" {
   type        = string
   description = "Subnet id for container EC2 instance"
 }
+
+variable "instance_ssh_key_pair_name" {
+  type        = string
+  default     = null
+  description = "The key pair name to use to access the EC2 instance"
+}
+
+variable "instance_enable_public_ip" {
+  type        = bool
+  default     = false
+  description = "If true, assigns a public ip to the EC2 instance"
+}


### PR DESCRIPTION
I noticed there was not a way to get into the EC2 instance - I use a bastion server and wanted to apply a keypair to it.

I also saw that there was output for a public ip. I wasn't sure what the default value was for enabling this, but made sure it's `false` to prevent exposure to the internet unless explicitly intended.